### PR TITLE
[FIX] Remove deprecated dotlearn setting.

### DIFF
--- a/.learn
+++ b/.learn
@@ -8,4 +8,4 @@ resources: 0
 events:
   intro_track_complete: true
 after_ide_submission: https://learn.co/ide/first_lab
-github: false
+


### PR DESCRIPTION
The `github: false` setting for the `.learn` configuration is a deprecated setting that historically was used for simulating an experience for new Learn students of submitting to Github. This setting should not be used anymore as it is no longer supported by our system and will result in any student using this lab attempting to submit their lesson with a failure.